### PR TITLE
Fix memory leaks when CDCImpl fails to construct

### DIFF
--- a/src/CDCImpl.cpp
+++ b/src/CDCImpl.cpp
@@ -270,7 +270,7 @@ CDCImplPrivate::CDCImplPrivate(const char* portName)
 void CDCImplPrivate::init()
 {
     //createNewLogFile();
-    m_transmitBuffer = ant_new unsigned char[1024];;
+    m_transmitBuffer = std::unique_ptr<unsigned char[]>(ant_new unsigned char[1024]);
     m_transmitBufferLen = 1024;
 
     portHandle = openPort(m_commPort);
@@ -327,7 +327,6 @@ CDCImplPrivate::~CDCImplPrivate()
     closePort(portHandle);
 
     delete msgParser;
-    delete[] m_transmitBuffer;
 
     //flog.close();
 }
@@ -550,13 +549,12 @@ CDCImplPrivate::BuffCommand CDCImplPrivate::commandToBuffer(Command& cmd)
 
     size_t sz = tmpStr.size();
     if (m_transmitBufferLen < sz) { //reallocate
-        delete[] m_transmitBuffer;
-        m_transmitBuffer = ant_new unsigned char[sz];
+        m_transmitBuffer = std::unique_ptr<unsigned char[]>(ant_new unsigned char[sz]);
         m_transmitBufferLen = static_cast<DWORD>(sz);
     }
 
     BuffCommand buffCmd;
-    buffCmd.cmd = m_transmitBuffer;
+    buffCmd.cmd = m_transmitBuffer.get();
     tmpStr.copy(buffCmd.cmd, sz);
     buffCmd.len = static_cast<DWORD>(sz);
 

--- a/src/CDCImplPri.h
+++ b/src/CDCImplPri.h
@@ -26,6 +26,7 @@
 #include <thread>
 #include <mutex>
 #include <string>
+#include <memory>
 
 #ifdef WIN32
 //typedef void* HANDLE;
@@ -184,7 +185,7 @@ public:
     HANDLE openPort(const std::string& portName);
     void closePort(HANDLE & portHandle);
 
-    unsigned char* m_transmitBuffer;
+    std::unique_ptr<unsigned char[]> m_transmitBuffer;
     DWORD m_transmitBufferLen;
 
 };

--- a/src/CDCImpl_Win.cpp
+++ b/src/CDCImpl_Win.cpp
@@ -385,11 +385,11 @@ HANDLE CDCImplPrivate::openPort(const std::string& portName)
         FILE_FLAG_OVERLAPPED, // overlapped operation
         NULL); //   must be NULL for comm devices
 
+    delete[] completePortName;
+
     //  Handle the error.
     if (portHandle == INVALID_HANDLE_VALUE)
         THROW_EXCEPT(CDCImplException, "Port handle creation failed with error " << GetLastError());
-
-    delete[] completePortName;
 
     DCB dcb;
     //SecureZeroMemory(&dcb, sizeof(DCB));


### PR DESCRIPTION
Let's consider the following code:

```c++
#include <CDCImpl.h>
#include <iostream>
#include <memory>

int main()
{
    try
    {
        std::unique_ptr<CDCImpl> impl = std::make_unique<CDCImpl>("COM4");
    }
    catch (...)
    {
        std::cerr << "Failure\n";
        return EXIT_FAILURE;
    }

    return EXIT_SUCCESS;
}
```

When `CDCImpl` fails to construct (for example: no device is connected to the `COM4` port), the `std::unique_ptr` should free all the memory. However, memory leaks in two different places:
```
Dumping objects ->
C:\Users\...\Desktop\clibcdc\src\CDCImpl_Win.cpp(500) : {175} normal block at 0x00000251EA6357D0, 9 bytes long.
 Data: <\\.\COM4 > 5C 5C 2E 5C 43 4F 4D 34 00 
C:\Users\...\Desktop\clibcdc\src\CDCImpl.cpp(273) : {173} normal block at 0x00000251EA637020, 1024 bytes long.
 Data: <                > CD CD CD CD CD CD CD CD CD CD CD CD CD CD CD CD 
Object dump complete.
```

This PR fixes that.